### PR TITLE
Force cuda since torch ask for a device, not if cuda is in fact avail…

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,9 +12,17 @@
 ### CUDA kernel for MSDeformAttn
 After preparing the required environment, run the following command to compile CUDA kernel for MSDeformAttn:
 
+`CUDA_HOME` must be defined and points to the directory of the installed CUDA toolkit.
+
 ```bash
 cd mask2former/modeling/pixel_decoder/ops
 sh make.sh
+```
+
+#### Building on another system
+To build on a system that does not have a GPU device but provide the drivers:
+```bash
+TORCH_CUDA_ARCH_LIST='8.0' FORCE_CUDA=1 python setup.py build install
 ```
 
 ### Example conda environment setup

--- a/mask2former/modeling/pixel_decoder/ops/setup.py
+++ b/mask2former/modeling/pixel_decoder/ops/setup.py
@@ -49,9 +49,9 @@ def get_extensions():
         ]
     else:
         if CUDA_HOME is None:
-            raise NotImplementedError('CUDA_HOME is None. Please set environmental variable CUDA_HOME or CUDA_PATH.')
+            raise NotImplementedError('CUDA_HOME is None. Please set environment variable CUDA_HOME.')
         else:
-            raise NotImplementedError('No CUDA runtime is found. Please test it by running torch.cuda.is_available().')
+            raise NotImplementedError('No CUDA runtime is found. Please set FORCE_CUDA=1 or test it by running torch.cuda.is_available().')
 
     sources = [os.path.join(extensions_dir, s) for s in sources]
     include_dirs = [extensions_dir]

--- a/mask2former/modeling/pixel_decoder/ops/setup.py
+++ b/mask2former/modeling/pixel_decoder/ops/setup.py
@@ -36,7 +36,8 @@ def get_extensions():
     extra_compile_args = {"cxx": []}
     define_macros = []
 
-    if torch.cuda.is_available() and CUDA_HOME is not None:
+    # Force cuda since torch ask for a device, not if cuda is in fact available.
+    if (os.environ.get('FORCE_CUDA') or torch.cuda.is_available()) and CUDA_HOME is not None:
         extension = CUDAExtension
         sources += source_cuda
         define_macros += [("WITH_CUDA", None)]


### PR DESCRIPTION
Force cuda since torch ask for a device, not if cuda is in fact available.

`torch.cuda.is_available()` is misleading since it actually checks for an available device, not if cuda is available.
Building on build-nodes where a gpu device is not necessarily available then fails. Force cuda through `FORCE_CUDA=1` to allow building.