### PR TITLE
fix UserWarning for floor division in position encoder

### DIFF
--- a/mask2former/modeling/transformer_decoder/position_encoding.py
+++ b/mask2former/modeling/transformer_decoder/position_encoding.py
@@ -38,7 +38,7 @@ class PositionEmbeddingSine(nn.Module):
             x_embed = x_embed / (x_embed[:, :, -1:] + eps) * self.scale
 
         dim_t = torch.arange(self.num_pos_feats, dtype=torch.float32, device=x.device)
-        dim_t = self.temperature ** (2 * (dim_t // 2) / self.num_pos_feats)
+        dim_t = self.temperature ** (2 * torch.div(dim_t, 2, rounding_mode='trunc') / self.num_pos_feats)
 
         pos_x = x_embed[:, :, :, None] / dim_t
         pos_y = y_embed[:, :, :, None] / dim_t


### PR DESCRIPTION
Torch currently throws a UserWarning for a division op in the position encoding module. 

```
UserWarning: __floordiv__ is deprecated, and its behavior will change in a future version of pytorch. It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). 
This results in incorrect rounding for negative values. To keep the current behavior, use torch.div(a, b, rounding_mode='trunc'), or for actual floor division, use torch.div(a, b, rounding_mode='floor')
```

Using the `trunc` rounding mode retains current behaviour, but presumably `floor` would also be fine here as `dim_t` should never be negative.

EDIT: (There may be more places that I haven't triggered...!)