### PR TITLE
fix access of 'iscrowd' without default value

### DIFF
--- a/mask2former/data/dataset_mappers/mask_former_panoptic_dataset_mapper.py
+++ b/mask2former/data/dataset_mappers/mask_former_panoptic_dataset_mapper.py
@@ -145,7 +145,7 @@ class MaskFormerPanopticDatasetMapper(MaskFormerSemanticDatasetMapper):
         masks = []
         for segment_info in segments_info:
             class_id = segment_info["category_id"]
-            if not segment_info["iscrowd"]:
+            if not segment_info.get("iscrowd", 0):
                 classes.append(class_id)
                 masks.append(pan_seg_gt == segment_info["id"])
 


### PR DESCRIPTION
The dataset mapper assumes 'iscrowd' is in the dataset, so I changed it to the .get('iscrowd',0) that is used to access this in the rest of the detectron2 codebase so that this can work on other custom datasets.